### PR TITLE
fetcher crashes with media-threads

### DIFF
--- a/Board/Yotsuba.pm
+++ b/Board/Yotsuba.pm
@@ -238,7 +238,7 @@ sub get_media($$){
 	
 	$post->{link} or $self->error(FORGET_IT,"This post doesn't have any media"),return;
 	
-	my $data=$self->wget("$post->{link}?" . time);
+	my ($data,undef)=$self->wget("$self->{img_link}/src/$post->{media_filename}?" . time);
 	
 	\$data;
 }


### PR DESCRIPTION
This just forces the `img_link` set at the bottom of `Board/Yotsuba.pm` to be used when grabbing the full image.

4chan's layout was modified to support HTTPS by removal of the protocol in the URL. This caused the fetcher to crash prematurely and takes the media queue with it. The thumbnails are fine since it uses the `preview_link` variable set.
